### PR TITLE
(fix): eslint import/no-unresolved issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "funding": "https://jaywcjlove.github.io/#/sponsor",
   "license": "MIT",
   "sideEffects": false,
+  "main": "./lib/index.js",
   "type": "module",
-	"types": "./lib/index.d.ts",
+  "types": "./lib/index.d.ts",
   "exports": "./lib/index.js",
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
Because of the missing 'main' key the eslint-plugin-import:resolver:node cannot resolve the package as a directory, thus throwing import/unresolved error/warning.

Here's the link to the place in code that is failing: https://github.com/browserify/resolve/blob/fd788d94d037e32d4f4be948e2f7e15f6981f004/lib/sync.js#L180

If the main is not set, it defaults to index.js in the package's root folder, you're exporting index.js and declaration in the dist directory thus it's producing an error in the code pointed upper.